### PR TITLE
Add last_modified_at computed property to place data

### DIFF
--- a/place/place.11tydata.mjs
+++ b/place/place.11tydata.mjs
@@ -15,6 +15,38 @@ export default {
 				const dateB = new Date(b.date);
 				return dateB - dateA;
 			});
+		},
+		last_modified_at: (data) => {
+			// Get the current last_modified_at value
+			const currentLastModified = data.last_modified_at ? new Date(data.last_modified_at) : null;
+			
+			// Get reviews from the frontmatter
+			const reviews = data.reviews || [];
+			
+			// Find the latest review date
+			let latestReviewDate = null;
+			if (Array.isArray(reviews) && reviews.length > 0) {
+				// Get all review dates and find the maximum
+				const reviewDates = reviews
+					.filter(review => review.date)
+					.map(review => new Date(review.date));
+				
+				if (reviewDates.length > 0) {
+					latestReviewDate = new Date(Math.max(...reviewDates));
+				}
+			}
+			
+			// Compare and return the later date
+			if (!currentLastModified && !latestReviewDate) {
+				return null;
+			} else if (!currentLastModified) {
+				return latestReviewDate.toISOString().split('T')[0];
+			} else if (!latestReviewDate) {
+				return currentLastModified.toISOString().split('T')[0];
+			} else {
+				const laterDate = currentLastModified > latestReviewDate ? currentLastModified : latestReviewDate;
+				return laterDate.toISOString().split('T')[0];
+			}
 		}
 	}
 };


### PR DESCRIPTION
## Summary
- Introduces a new computed property `last_modified_at` in `place.11tydata.mjs`
- Calculates the latest modification date based on existing `last_modified_at` and review dates
- Ensures the most recent date between the place's last modified date and its reviews is returned

## Changes

### Data Computation
- Added `last_modified_at` function to compute the latest modification date:
  - Retrieves current `last_modified_at` date if available
  - Extracts and parses review dates from the `reviews` array
  - Compares dates and returns the latest date in ISO format (YYYY-MM-DD)
  - Returns `null` if no dates are available

## Test plan
- [ ] Verify that `last_modified_at` returns the correct latest date when both place and reviews have dates
- [ ] Confirm it returns the place's last modified date if no reviews exist
- [ ] Confirm it returns the latest review date if place's last modified date is missing
- [ ] Confirm it returns `null` if no dates are present
- [ ] Test date formatting consistency in the output

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/98b02b58-6da1-4c04-b28b-311298914420