### PR TITLE
Fix markdown rendering in place reviews

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -100,6 +100,14 @@ module.exports = (config) => {
 		});
 	});
 
+	// Add markdown filter for rendering markdown content
+	const markdownIt = require("markdown-it");
+	const md = markdownIt({ html: true, linkify: true });
+	
+	config.addFilter("markdown", (content) => {
+		return md.render(content || "");
+	});
+
 	function updateSrc(img) {
 		const src = img.getAttribute("src");
 		if (src.startsWith("/")) {

--- a/_includes/place-reviews.liquid
+++ b/_includes/place-reviews.liquid
@@ -6,7 +6,7 @@ Display reviews for the current place using the computed placeReviews data
     {% assign prevDate = null %}
     {% assign prevUrl = null %}
     {% for review in placeReviews %}
-        <p>
+        <div class="review">
             {% unless review.date == prevDate and review.url == prevUrl %}
                 {% if review.url %}
                     <a href="{{ review.url }}">{{ review.date | date: "%B %Y" }}:</a>
@@ -14,8 +14,8 @@ Display reviews for the current place using the computed placeReviews data
                     {{ review.date | date: "%B %Y" }}:
                 {% endif %}
             {% endunless %}
-            "{{ review.text | newline_to_br }}"
-        </p>
+            {{ review.text | markdown }}
+        </div>
         {% assign prevDate = review.date %}
         {% assign prevUrl = review.url %}
     {% endfor %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@11ty/eleventy-img": "^5.0.0",
         "fast-glob": "^3.3.2",
         "jsdom": "^26.0.0",
+        "markdown-it": "^14.1.0",
         "prettier": "^3.5.3",
         "sass": "^1.86.3"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@11ty/eleventy-img": "^5.0.0",
     "fast-glob": "^3.3.2",
     "jsdom": "^26.0.0",
+    "markdown-it": "^14.1.0",
     "prettier": "^3.5.3",
     "sass": "^1.86.3"
   }


### PR DESCRIPTION
## Summary
- Adds a markdown filter to Eleventy configuration for rendering markdown content
- Updates place reviews template to render review text as markdown instead of plain text with line breaks
- Adds `markdown-it` dependency to support markdown rendering

## Changes

### Eleventy Configuration
- Introduced a new `markdown` filter using `markdown-it` to convert markdown strings to HTML

### Template Updates
- Modified `_includes/place-reviews.liquid` to use the new `markdown` filter for review text
- Changed review text container from `<p>` to `<div class="review">` for better styling and structure

### Dependencies
- Added `markdown-it` to `package.json` and `package-lock.json` to enable markdown processing

## Test plan
- [x] Verify that place reviews render markdown correctly (e.g., links, formatting)
- [x] Confirm no regression in review date and URL display
- [x] Check that the new filter does not break other markdown usages in the site if any

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f87f5cbf-b933-4df6-af2d-23e5dab666f2